### PR TITLE
fix: update urls to remove dependency on aws s3

### DIFF
--- a/.github/workflows/update-release.yml
+++ b/.github/workflows/update-release.yml
@@ -21,7 +21,7 @@ jobs:
           echo "$env:SCOOP\shims" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
       - name: Update Manifest
         run: |
-          .\scripts\updatever.ps1
+          .\scripts\updatever.ps1 -version ${{github.event.inputs.version}}
       - name: Verify and update hashes
         run: |
           # Update hashes in case checksum isn't correctly updated

--- a/scripts/updatever.ps1
+++ b/scripts/updatever.ps1
@@ -1,4 +1,11 @@
+param(
+    [String] $version = ''
+)
 if(!$env:SCOOP_HOME) { $env:SCOOP_HOME = Resolve-Path (scoop prefix scoop) }
 $checkver = "$env:SCOOP_HOME/bin/checkver.ps1"
 $dir = "$psscriptroot/../" # checks the parent dir
-Invoke-Expression -command "& '$checkver' -dir '$dir' $($args | ForEach-Object { "$_ " }) -Update"
+if($version -like "*draft*"){
+    Invoke-Expression -command "& '$checkver' -a '$psscriptroot/../twiliodraft.json' -Update -v '$version'"
+}else{
+    Invoke-Expression -command "& '$checkver' -dir '$dir' $($args | ForEach-Object { "$_ " }) -Update"
+}

--- a/twilio.json
+++ b/twilio.json
@@ -5,32 +5,32 @@
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://twilio-cli-prod.s3.amazonaws.com/twilio-win32-x64.tar.xz",
+            "url": "https://github.com/twilio/twilio-cli/releases/download/5.1.0/twilio-win32-x64.tar.xz",
             "hash": "ad6d52e5ff3e5f85e7c769b6773ff8c6e30d69581f730180a7b7d6bd34a93eda"
         },
         "32bit": {
-            "url": "https://twilio-cli-prod.s3.amazonaws.com/twilio-win32-x86.tar.xz",
+            "url": "https://github.com/twilio/twilio-cli/releases/download/5.1.0/twilio-win32-x86.tar.xz",
             "hash": "b3befe1ea8f9249a94439d9f85226ef55d4ca8fcaf175ec5f725d15db589f5da"
         }
     },
     "bin": "twilio\\bin\\twilio.cmd",
     "checkver": {
-        "url": "https://twilio-cli-prod.s3.amazonaws.com/version",
+        "url": "https://github.com/twilio/twilio-cli/releases/latest/download/version",
         "jsonpath": "$.version"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://twilio-cli-prod.s3.amazonaws.com/twilio-win32-x64.tar.xz",
+                "url": "https://github.com/twilio/twilio-cli/releases/download/$version/twilio-win32-x64.tar.xz",
                 "hash": {
-                    "url": "https://twilio-cli-prod.s3.amazonaws.com/win32-x64",
+                    "url": "https://github.com/twilio/twilio-cli/releases/download/$version/win32-x64",
                     "jsonpath": "$.sha256xz"
                 }
             },
             "32bit": {
-                "url": "https://twilio-cli-prod.s3.amazonaws.com/twilio-win32-x86.tar.xz",
+                "url": "https://github.com/twilio/twilio-cli/releases/download/$version/twilio-win32-x86.tar.xz",
                 "hash": {
-                    "url": "https://twilio-cli-prod.s3.amazonaws.com/win32-x86",
+                    "url": "https://github.com/twilio/twilio-cli/releases/download/$version/win32-x86",
                     "jsonpath": "$.sha256xz"
                 }
             }

--- a/twiliodraft.json
+++ b/twiliodraft.json
@@ -5,32 +5,32 @@
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://twilio-cli-prod.s3.amazonaws.com/channels/draft/twilio-win32-x64.tar.xz",
-            "hash": "ed9ff6403f0ca7b18ab8007de819e6a7c1e12cde56e285620c04b0ce281094c8"
+            "url": "https://github.com/twilio/twilio-cli/releases/download/3.1.0-draft.1/twilio-win32-x64.tar.xz",
+            "hash": "259a18e1439be469ba995ef71394e2b7e514296e504962c602751d7a76ae5ca1"
         },
         "32bit": {
-            "url": "https://twilio-cli-prod.s3.amazonaws.com/channels/draft/twilio-win32-x86.tar.xz",
-            "hash": "ed66dea39c8d58e62c0cce7e324c5014a5407c9af9f6d65dec039c1c10b397df"
+            "url": "https://github.com/twilio/twilio-cli/releases/download/3.1.0-draft.1/twilio-win32-x86.tar.xz",
+            "hash": "2ef7ce4f7d07885d984ac84b05222d6e50f4dbfe4a2ff54afd76013af09a0f3a"
         }
     },
     "bin": "twilio\\bin\\twilio.cmd",
     "checkver": {
-        "url": "https://twilio-cli-prod.s3.amazonaws.com/channels/draft/version",
+        "url": "https://github.com/twilio/twilio-cli/releases/download/$version/version",
         "jsonpath": "$.version"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://twilio-cli-prod.s3.amazonaws.com/channels/draft/twilio-win32-x64.tar.xz",
+                "url": "https://github.com/twilio/twilio-cli/releases/download/$version/twilio-win32-x64.tar.xz",
                 "hash": {
-                    "url": "https://twilio-cli-prod.s3.amazonaws.com/channels/draft/win32-x64",
+                    "url": "https://github.com/twilio/twilio-cli/releases/download/$version/win32-x64",
                     "jsonpath": "$.sha256xz"
                 }
             },
             "32bit": {
-                "url": "https://twilio-cli-prod.s3.amazonaws.com/channels/draft/twilio-win32-x86.tar.xz",
+                "url": "https://github.com/twilio/twilio-cli/releases/download/$version/twilio-win32-x86.tar.xz",
                 "hash": {
-                    "url": "https://twilio-cli-prod.s3.amazonaws.com/channels/draft/win32-x86",
+                    "url": "https://github.com/twilio/twilio-cli/releases/download/$version/win32-x86",
                     "jsonpath": "$.sha256xz"
                 }
             }


### PR DESCRIPTION
<!-- Describe your Pull Request -->

# Fixes [DII-694](https://issues.corp.twilio.com/browse/DII-694)
The urls are modified to pickup artefacts from cli release assets instead of aws-s3 bucket.
For more context, refer [this PR](https://github.com/twilio/twilio-cli/pull/474).

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
