### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/update-release.yml
+++ b/.github/workflows/update-release.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Check for release type
         id: prereleaseflag
         run : |
-            echo "::set-output name=prerelease::${{ contains(github.event.inputs.version, 'draft' ) }}"  
+            echo "prerelease=${{ contains(github.event.inputs.version, 'draft' ) }}" >> $GITHUB_OUTPUT  
       - name: Create a GitHub release
         uses: ncipollo/release-action@v1
         with:


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `set-output` to `$GITHUB_OUTPUT`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter


